### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: "1"
 


### PR DESCRIPTION
Potential fix for [https://github.com/reservoir-data/tap-criteo/security/code-scanning/3](https://github.com/reservoir-data/tap-criteo/security/code-scanning/3)

In general, you fix this by explicitly declaring a `permissions` block in the workflow (at the root or per job) that grants only the minimal access the job needs. For a typical test workflow that just checks out code and runs tests, `contents: read` is usually sufficient.

For this specific workflow in `.github/workflows/test.yml`, the job only checks out the repo and runs tests; there is no evidence of actions that require write access to repository contents, issues, or pull requests. The safest, least-privilege change that preserves existing behavior is to add a root-level `permissions` block with `contents: read`. This applies to all jobs (currently just `tests`) and leaves everything else unchanged.

Concretely, in `.github/workflows/test.yml`, insert:

```yml
permissions:
  contents: read
```

between the `concurrency` block (lines 10–12) and the existing `env` block (line 14). No other imports or structural changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
